### PR TITLE
tbtadm: Handle legacy device approval in SL2

### DIFF
--- a/tbtadm/controller.cpp
+++ b/tbtadm/controller.cpp
@@ -502,7 +502,7 @@ void tbtadm::Controller::approve(const fs::path& dir) try
     }
 
     std::ostringstream keyStream;
-    if (m_sl == 2)
+    if (m_sl == 2 && !m_once)
     {
         std::default_random_engine eng(std::random_device{}());
         std::uniform_int_distribution<> dist(0, 0xF);


### PR DESCRIPTION
Legacy devices do not have "key" attribute but we should still allow
user to approve them when --once is passed.

Signed-off-by: Mika Westerberg <mika.westerberg@linux.intel.com>