### PR TITLE
docs: Describe peers command in the manual page

### DIFF
--- a/docs/tbtadm.t2t
+++ b/docs/tbtadm.t2t
@@ -15,6 +15,8 @@ tbtadm - Thunderbolt(tm) management tool
 
 **tbtadm devices**
 
+**tbtadm peers**
+
 **tbtadm topology**
 
 **tbtadm approve** [--once] <route-string>
@@ -44,8 +46,15 @@ format:
 Route-string    Vendor    Device name    Authorized?    In ACL?
 ```
 
+: **peers**
+Print a list of all the currently connected hosts in the following
+format:
+```
+Route-string    Vendor    Device name
+```
+
 : **topology**
-Print all the currently connected Thudnerbolt devices in a tree, starting with
+Print all the currently connected Thunderbolt devices in a tree, starting with
 the controller itself, resembling the device connection topology.
 
 : **approve** [--once] <route-string>


### PR DESCRIPTION
While there fix a typo in topology command description.

Signed-off-by: Mika Westerberg <mika.westerberg@linux.intel.com>