### PR TITLE
RFC: continue with ACL if device already authorized

### DIFF
--- a/tbtadm/controller.cpp
+++ b/tbtadm/controller.cpp
@@ -578,6 +578,8 @@ void tbtadm::Controller::approveAll(const fs::path& dir)
 // TODO: move to tbtadm-helper
 void tbtadm::Controller::approve(const fs::path& dir) try
 {
+    bool already_authorized = false;
+
     chdir(dir);
     m_out << "Authorizing " << dir << '\n';
 
@@ -585,7 +587,7 @@ void tbtadm::Controller::approve(const fs::path& dir) try
     if (std::stoi(authorized.read()))
     {
         m_out << "Already authorized\n";
-        return;
+        already_authorized = true;
     }
 
     if (!m_once)
@@ -607,8 +609,10 @@ void tbtadm::Controller::approve(const fs::path& dir) try
         key << keyStream.str();
     }
 
-    authorized = File(authorizedFilename, File::Mode::Write);
-    authorized << 1;
+    if (!already_authorized) {
+        authorized = File(authorizedFilename, File::Mode::Write);
+        authorized << 1;
+    }
 
     m_out << "Authorized\n";
     if (m_sl == 2 && !m_once)

--- a/tbtadm/controller.cpp
+++ b/tbtadm/controller.cpp
@@ -586,8 +586,14 @@ void tbtadm::Controller::approve(const fs::path& dir) try
     File authorized(authorizedFilename, File::Mode::Read);
     if (std::stoi(authorized.read()))
     {
-        m_out << "Already authorized\n";
+        m_out << "Already authorized, checking could we add to ACL\n";
         already_authorized = true;
+
+        if (m_sl == 2)
+        {
+            m_out << "Cannot approve already authorized devices in SL2 mode\n";
+            return;
+        }
     }
 
     if (!m_once)
@@ -609,12 +615,13 @@ void tbtadm::Controller::approve(const fs::path& dir) try
         key << keyStream.str();
     }
 
-    if (!already_authorized) {
+    if (!already_authorized)
+    {
         authorized = File(authorizedFilename, File::Mode::Write);
         authorized << 1;
+        m_out << "Authorized\n";
     }
 
-    m_out << "Authorized\n";
     if (m_sl == 2 && !m_once)
     {
         File keyACL(acltree / readAndTrim(uniqueIDFilename) / keyFilename,


### PR DESCRIPTION
In a case device is authorized during boot time approve should just
add device to ACL.

Fixes: #34