### PR TITLE
CI: Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+script:
+  - mkdir build && cd build && cmake .. && cmake --build .
+matrix:
+  include:
+    compiler:
+      - gcc
+      # clang
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - libboost-filesystem-dev
+          - libboost-program-options-dev
+          - txt2tags
+          #- g++-4.8
+          - g++-7
+          #- libstdc++6-4.7-dev
+    env:
+      - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+before_install:
+  - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
Add configuration for Travis Continuous Integration platform which can
be easily integrated to github.