### PR TITLE
tbtadm: add `add` command

### DIFF
--- a/docs/tbtadm.t2t
+++ b/docs/tbtadm.t2t
@@ -25,6 +25,8 @@ tbtadm - Thunderbolt(tm) management tool
 
 **tbtadm acl**
 
+**tbtadm add** <route-string>
+
 **tbtadm remove** <uuid | route-string>
 
 **tbtadm remove-all**
@@ -70,6 +72,12 @@ Print the ACL content in the following format:
 ```
 UUID    Vendor    Device name    Currently connected?
 ```
+
+: **add** <route-string>
+Add a device to ACL. The argument selects the device to be added by its
+route-string. Doesn't work in SL2 (secure; key-based) as addition to ACL must be
+done together with the device authorization (with ``approve`` or ``approve-all``
+without ``--once`` flag).
 
 : **remove** <uuid | route-string>
 Remove ACL entry. The argument selects the device to be removed by its UUID or

--- a/tbtadm/controller.cpp
+++ b/tbtadm/controller.cpp
@@ -72,6 +72,7 @@ const std::string opt_topology    = "topology";
 const std::string opt_approve     = "approve";
 const std::string opt_approve_all = "approve-all";
 const std::string opt_acl         = "acl";
+const std::string opt_add         = "add";
 const std::string opt_remove      = "remove";
 const std::string opt_remove_all  = "remove-all";
 const std::string opt_once_flag   = "--once";
@@ -291,6 +292,14 @@ void tbtadm::Controller::run()
         {
             return acl();
         }
+        if (m_argv[1] == opt_add)
+        {
+            if (m_argc == 3)
+            {
+                m_sl = findSL();
+                return add(sysfsDevicesPath / m_argv[2]);
+            }
+        }
         if (m_argv[1] == opt_remove)
         {
             if (m_argc == 3)
@@ -309,8 +318,8 @@ void tbtadm::Controller::run()
     m_out << "Usage: " << opt_devices << sep << opt_peers << sep << opt_topology
           << sep << opt_approve << " [" << opt_once_flag << "] <route-string>"
           << sep << opt_approve_all << " [" << opt_once_flag << ']' << sep
-          << opt_acl << sep << opt_remove << " <uuid>|<route-string>" << sep
-          << opt_remove_all << "\n";
+          << opt_acl << sep << opt_add << " <route-string>" << sep << opt_remove
+          << " <uuid>|<route-string>" << sep << opt_remove_all << "\n";
     throw std::runtime_error("Wrong usage");
 }
 
@@ -738,6 +747,18 @@ void tbtadm::Controller::acl()
             }
         }
     }
+}
+
+void tbtadm::Controller::add(const fs::path& dir)
+{
+    if (m_sl == 2)
+    {
+        m_out << "Adding to ACL on SL2 must be done together with device "
+                 "approval\n";
+        return;
+    }
+    chdir(dir);
+    addToACL();
 }
 
 // TODO: move to tbtadm-helper

--- a/tbtadm/controller.h
+++ b/tbtadm/controller.h
@@ -85,6 +85,9 @@ private:
     /// Prints ACL
     void acl();
 
+    /// Add the given device to ACL
+    void add(const fs::path& dir);
+
     /// Removes the given UUID from ACL
     void remove(std::string uuid);
 

--- a/tbtadm/tbtadm.bash_completion
+++ b/tbtadm/tbtadm.bash_completion
@@ -8,10 +8,10 @@ _tbtadm()
     COMPREPLY=()
     cur="$2"
     command="${COMP_WORDS[1]}"
-    opts="devices peers topology approve approve-all acl remove remove-all"
+    opts="devices peers topology approve approve-all acl add remove remove-all"
 
     case "$command" in
-    approve|remove)
+    approve|add|remove)
         local routestrings
         routestrings="$( [ -d ${devices} ] && command ls ${devices} | command grep -v domain | command grep -Fv . | command grep -v [0-9]-0)"
         COMPREPLY+=( $(compgen -W "${routestrings}" -- "$cur") )


### PR DESCRIPTION
This allows the user to add a device to ACL without using `approve` or
`approve-all` commands, and thus allowing such addition even when the
device is already authorized (e.g. on pre-boot environment).
This can't work on SL2 because this is how the sysfs interface to the
driver is defined.

Resolves #34

Signed-off-by: Yehezkel Bernat <yehezkel.bernat@intel.com>