### PR TITLE
tests: Fix build errors in docker environment

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update -q && apt-get install -y \
     gir1.2-glib-2.0 \
     gir1.2-gudev-1.0 \
     python3-gi \
+    umockdev \
+    gir1.2-umockdev-1.0 \
     locales \
     pkg-config \
     udev \

--- a/tests/docker-build.sh
+++ b/tests/docker-build.sh
@@ -5,15 +5,7 @@ set -e
 # Print executed commands
 set -x
 
-# Building in /usr/local/src
-pushd ..
-# Required commits are: bd14fb6 and 88d2cc3
-git clone https://github.com/martinpitt/umockdev.git
-pushd umockdev
-./autogen.sh --prefix=/usr && make -j4 && make install && popd
-popd
-
-echo "Returning to " `pwd`
+echo "Building in " `pwd`
 
 rm -rf build && mkdir build
 cd build && cmake .. && cmake --build .


### PR DESCRIPTION
At the moment building of umockdev is failing but we do not need it
since all needed changes were incorporated upstream and packaged at
least for debian/testing. This saves us time building umockdev in the
container out of sources.